### PR TITLE
add access to webhostenvironment

### DIFF
--- a/src/Saturn/Application.fs
+++ b/src/Saturn/Application.fs
@@ -217,12 +217,13 @@ module Application =
         host
       else
         host.ConfigureWebHostDefaults(fun wbhst ->
-          let wbhst = wbhst |> List.foldBack (fun e acc -> e acc ) state.WebHostConfigs
-          
+
           // allow access to WebHostEnvironment to other CEs (e.g. configure services)
           wbhst.ConfigureAppConfiguration(fun context config ->
                ApplicationBuilder.WebHostEnvironment <- context.HostingEnvironment 
                )
+
+          let wbhst = wbhst |> List.foldBack (fun e acc -> e acc ) state.WebHostConfigs
           
           let wbhst =
             if not (state.Urls |> List.isEmpty) then


### PR DESCRIPTION
CEs element or other configuration parts requiring IWebHostEnvironment instances can have access to it, for example 

```fsharp
 [<CustomOperationAttribute("custom_bootstrap")>]
    member this.CustomBootstrap (state : ApplicationState) =
        
        let service (services : IServiceCollection) =

            services.CustomBoostrap(
                ApplicationBuilder.WebHostEnvironment, //// <<< USED HERE
                (Config.getConfiguration(services)),
                fun opt ->
                    opt.ApplicationInformation.ApplicationName <- "Acme.WebApi.Template.ApplicationName"
                    opt.ApplicationInformation.ApplicationGroup <- "Acme.WebApi.Template.ApplicationGroup"
            )

        {  state with
            ServicesConfig = service::state.ServicesConfig
            }

```